### PR TITLE
Fix/#29 exception handling

### DIFF
--- a/src/main/java/org/stupid_talking_potatoes/kis/controller/NodeController.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/controller/NodeController.java
@@ -77,7 +77,7 @@ public class NodeController {
         } catch (NumberFormatException e) {
             throw BadRequestException.builder()
                     .message("longitude, latitude must be Double type")
-                    .content(e.getMessage().replace("\"", "'")) // 에러 메시지에 \"가 있어 작은 따옴표로 변경
+                    .content(e.getMessage())
                     .build();
         }
         List<NodeDto> response = nodeService.getAroundNodeInfo(_longitude, _latitude);

--- a/src/main/java/org/stupid_talking_potatoes/kis/controller/NodeController.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/controller/NodeController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.stupid_talking_potatoes.kis.dto.node.NodeDto;
 import org.stupid_talking_potatoes.kis.dto.node.RealtimeBusArrivalInfo;
+import org.stupid_talking_potatoes.kis.exception.BadRequestException;
 import org.stupid_talking_potatoes.kis.service.NodeService;
 
 import java.util.List;
@@ -24,7 +25,13 @@ import java.util.List;
 @RequestMapping("/api/nodes")
 public class NodeController {
     private final NodeService nodeService;
-    
+
+    /**
+     * 정류장 번호, 이름으로 검색하여 정류장 리스트를 응답하는 API
+     * @param nodeNo 검색할 정류장 번호
+     * @param nodeName 검색할 정류장 이름
+     * @return 검색 결과 List
+     */
     @GetMapping("/search")
     public ResponseEntity getNodeList(
             @RequestParam(name="no", required = false) String nodeNo,
@@ -35,7 +42,12 @@ public class NodeController {
                 .status(HttpStatus.OK)
                 .body(response);
     }
-    
+
+    /**
+     * 정류장 ID로 검색하여 해당 정류장에 대한 버스 도착 정보를 응답하는 API
+     * @param nodeId 정류장 ID
+     * @return 정류장 정보 및 해당 정류장의 버스 도착 정보 List
+     */
     @GetMapping("/arrive-info")
     public ResponseEntity getRealtimeBusArrivalInfo(
             @RequestParam(name="id") String nodeId
@@ -45,7 +57,13 @@ public class NodeController {
                 .status(HttpStatus.OK)
                 .body(response);
     }
-    
+
+    /**
+     * 좌표를 중심으로 반경 500m 내의 버스 정류장을 응답하는 API
+     * @param longitude 경도
+     * @param latitude 위도
+     * @return 버스 정류장 List
+     */
     @GetMapping("")
     public ResponseEntity getAroundNodeInfo(
             @RequestParam String longitude,
@@ -57,8 +75,10 @@ public class NodeController {
             _longitude = Double.valueOf(longitude);
             _latitude = Double.valueOf(latitude);
         } catch (NumberFormatException e) {
-            // TODO: Handle exception
-            throw new RuntimeException();
+            throw BadRequestException.builder()
+                    .message("longitude, latitude must be Double type")
+                    .content(e.getMessage().replace("\"", "'")) // 에러 메시지에 \"가 있어 작은 따옴표로 변경
+                    .build();
         }
         List<NodeDto> response = nodeService.getAroundNodeInfo(_longitude, _latitude);
         return ResponseEntity

--- a/src/main/java/org/stupid_talking_potatoes/kis/exception/BadRequestException.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/exception/BadRequestException.java
@@ -4,13 +4,10 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class BadRequestException extends RuntimeException {
-    private String message;
-    private String content;
+public class BadRequestException extends BaseException {
 
     @Builder
     public BadRequestException(String message, String content) {
-        this.message = message;
-        this.content = content;
+        super(message, content);
     }
 }

--- a/src/main/java/org/stupid_talking_potatoes/kis/exception/BadRequestException.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/exception/BadRequestException.java
@@ -2,12 +2,12 @@ package org.stupid_talking_potatoes.kis.exception;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public class BadRequestException extends BaseException {
-
     @Builder
     public BadRequestException(String message, String content) {
-        super(message, content);
+        super(message, content, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/org/stupid_talking_potatoes/kis/exception/BadRequestException.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/exception/BadRequestException.java
@@ -1,0 +1,16 @@
+package org.stupid_talking_potatoes.kis.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class BadRequestException extends RuntimeException {
+    private String message;
+    private String content;
+
+    @Builder
+    public BadRequestException(String message, String content) {
+        this.message = message;
+        this.content = content;
+    }
+}

--- a/src/main/java/org/stupid_talking_potatoes/kis/exception/BaseException.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/exception/BaseException.java
@@ -1,0 +1,11 @@
+package org.stupid_talking_potatoes.kis.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public abstract class BaseException extends RuntimeException {
+    private String message;
+    private String content;
+}

--- a/src/main/java/org/stupid_talking_potatoes/kis/exception/BaseException.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/exception/BaseException.java
@@ -1,11 +1,18 @@
 package org.stupid_talking_potatoes.kis.exception;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
-@AllArgsConstructor
 public abstract class BaseException extends RuntimeException {
     private String message;
     private String content;
+    private HttpStatus statusCode;
+
+    public BaseException(String message, String content, HttpStatus statusCode) {
+        // 문자열에 \"가 있는 경우 작은 따옴표로 변경
+        this.message = message.replace("\"", "'");
+        this.content = content.replace("\"", "'");
+        this.statusCode = statusCode;
+    }
 }

--- a/src/main/java/org/stupid_talking_potatoes/kis/exception/ErrorResponse.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/exception/ErrorResponse.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public class ErrorResponse {
     private String message;
     private String content;
+
     public ErrorResponse(String message, String content) {
         this.message = message;
         this.content = content;

--- a/src/main/java/org/stupid_talking_potatoes/kis/exception/ErrorResponse.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/exception/ErrorResponse.java
@@ -1,0 +1,13 @@
+package org.stupid_talking_potatoes.kis.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+    private String message;
+    private String content;
+    public ErrorResponse(String message, String content) {
+        this.message = message;
+        this.content = content;
+    }
+}

--- a/src/main/java/org/stupid_talking_potatoes/kis/exception/ExceptionAdvice.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/exception/ExceptionAdvice.java
@@ -8,11 +8,11 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class ExceptionAdvice {
 
-    @ExceptionHandler({BadRequestException.class, NotFoundException.class})
+    @ExceptionHandler({BaseException.class})
     public ResponseEntity<ErrorResponse> baseExceptionHandler(BaseException e) {
         ErrorResponse response = new ErrorResponse(e.getMessage(), e.getContent());
         return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
+                .status(e.getStatusCode())
                 .body(response);
     }
 }

--- a/src/main/java/org/stupid_talking_potatoes/kis/exception/ExceptionAdvice.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/exception/ExceptionAdvice.java
@@ -8,19 +8,11 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class ExceptionAdvice {
 
-    @ExceptionHandler(BadRequestException.class)
-    public ResponseEntity badRequestException(BadRequestException e) {
+    @ExceptionHandler({BadRequestException.class, NotFoundException.class})
+    public ResponseEntity<ErrorResponse> notFoundException(BaseException e) {
         ErrorResponse response = new ErrorResponse(e.getMessage(), e.getContent());
         return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(response);
-    }
-
-    @ExceptionHandler(NotFoundException.class)
-    public ResponseEntity<ErrorResponse> notFoundException(NotFoundException e) {
-        ErrorResponse response = new ErrorResponse(e.getMessage(), e.getContent());
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
+                .status(HttpStatus.NOT_FOUND)
                 .body(response);
     }
 }

--- a/src/main/java/org/stupid_talking_potatoes/kis/exception/ExceptionAdvice.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/exception/ExceptionAdvice.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class ExceptionAdvice {
 
     @ExceptionHandler({BadRequestException.class, NotFoundException.class})
-    public ResponseEntity<ErrorResponse> notFoundException(BaseException e) {
+    public ResponseEntity<ErrorResponse> baseExceptionHandler(BaseException e) {
         ErrorResponse response = new ErrorResponse(e.getMessage(), e.getContent());
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)

--- a/src/main/java/org/stupid_talking_potatoes/kis/exception/ExceptionAdvice.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/exception/ExceptionAdvice.java
@@ -1,0 +1,26 @@
+package org.stupid_talking_potatoes.kis.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ExceptionAdvice {
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity badRequestException(BadRequestException e) {
+        ErrorResponse response = new ErrorResponse(e.getMessage(), e.getContent());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(response);
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ErrorResponse> notFoundException(NotFoundException e) {
+        ErrorResponse response = new ErrorResponse(e.getMessage(), e.getContent());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(response);
+    }
+}

--- a/src/main/java/org/stupid_talking_potatoes/kis/exception/InternalServerException.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/exception/InternalServerException.java
@@ -1,0 +1,13 @@
+package org.stupid_talking_potatoes.kis.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class InternalServerException extends BaseException {
+    @Builder
+    public InternalServerException(String message, String content) {
+        super(message, content, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/org/stupid_talking_potatoes/kis/exception/NotFoundException.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/exception/NotFoundException.java
@@ -1,13 +1,12 @@
 package org.stupid_talking_potatoes.kis.exception;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class NotFoundException extends RuntimeException {
-    private String message;
-    private String content;
+public class NotFoundException extends BaseException {
+    @Builder
     public NotFoundException(String message, String content) {
-        this.message = message;
-        this.content = content;
+        super(message, content);
     }
 }

--- a/src/main/java/org/stupid_talking_potatoes/kis/exception/NotFoundException.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/exception/NotFoundException.java
@@ -2,11 +2,12 @@ package org.stupid_talking_potatoes.kis.exception;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public class NotFoundException extends BaseException {
     @Builder
     public NotFoundException(String message, String content) {
-        super(message, content);
+        super(message, content, HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/java/org/stupid_talking_potatoes/kis/exception/NotFoundException.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/exception/NotFoundException.java
@@ -1,0 +1,13 @@
+package org.stupid_talking_potatoes.kis.exception;
+
+import lombok.Getter;
+
+@Getter
+public class NotFoundException extends RuntimeException {
+    private String message;
+    private String content;
+    public NotFoundException(String message, String content) {
+        this.message = message;
+        this.content = content;
+    }
+}

--- a/src/main/java/org/stupid_talking_potatoes/kis/exception/ThirdPartyAPIException.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/exception/ThirdPartyAPIException.java
@@ -1,0 +1,13 @@
+package org.stupid_talking_potatoes.kis.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ThirdPartyAPIException extends BaseException {
+    @Builder
+    public ThirdPartyAPIException(String message, String content) {
+        super(message, content, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/org/stupid_talking_potatoes/kis/service/NodeService.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/service/NodeService.java
@@ -6,6 +6,7 @@ import org.stupid_talking_potatoes.kis.dto.node.NodeDto;
 import org.stupid_talking_potatoes.kis.dto.node.RealtimeBusArrivalInfo;
 import org.stupid_talking_potatoes.kis.dto.route.ArrivalRoute;
 import org.stupid_talking_potatoes.kis.entity.Node;
+import org.stupid_talking_potatoes.kis.exception.NotFoundException;
 import org.stupid_talking_potatoes.kis.repository.NodeRepository;
 
 import java.util.*;
@@ -55,7 +56,7 @@ public class NodeService {
     }
     
     public RealtimeBusArrivalInfo getRealtimeBusArrivalInfo(String nodeId){
-        Node node = nodeRepository.findById(nodeId).orElseThrow(()-> new NoSuchElementException());
+        Node node = nodeRepository.findById(nodeId).orElseThrow(()-> new NotFoundException("Node is not found", nodeId));
         
         // get response from tago service
         List<ArrivalRoute> arrivalRoutes = tagoService.requestRealtimeBusArrivalInfo(nodeId);

--- a/src/main/java/org/stupid_talking_potatoes/kis/service/NodeService.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/service/NodeService.java
@@ -10,6 +10,8 @@ import org.stupid_talking_potatoes.kis.exception.NotFoundException;
 import org.stupid_talking_potatoes.kis.repository.NodeRepository;
 
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * package :  org.stupid_talking_potatoes.kis.node.service
@@ -23,36 +25,29 @@ public class NodeService {
     
     private final NodeRepository nodeRepository;
     private final TAGOService tagoService;
-    
     private final RouteService routeService;
     
     
     /**
-     * nodeNo와 nodeName을 기준으로 node테이블의 요소를 NodeDto에 담아 리스트형태로 반환
-     *
-     * @param nodeNo nodeNo
-     * @param nodeName nodeName
-     * @return {@link ArrayList}
-     * @see ArrayList
-     * @see NodeDto
+     * nodeNo와 nodeName을 기준으로 node 테이블의 요소를 NodeDto에 담아 리스트형태로 반환
+     * @param nodeNo 정류장 번호
+     * @param nodeName 정류장명
+     * @return 정류장 정보가 담긴 NodeDto 리스트
      */
-    public ArrayList<NodeDto> getNodeList(String nodeNo, String nodeName){
-        ArrayList<NodeDto> nodeList = new ArrayList<>();
-        
+    public List<NodeDto> getNodeList(String nodeNo, String nodeName){
+        List<NodeDto> list = Collections.emptyList();
+
         if (nodeNo != null) {
             Optional<Node> node = nodeRepository.findByNodeNo(nodeNo);
             if (node.isPresent()) { // if node exists
-                nodeList.add(new NodeDto(node.get()));
+                list.add(new NodeDto(node.get()));
             } // else, not error but empty list
         }
         else if (nodeName != null) {
             List<Node> nodes = nodeRepository.findByNodeNameContaining(nodeName);
-            for (Node node : nodes) {
-                nodeList.add(new NodeDto(node));
-            }
+            return nodes.stream().map(NodeDto::new).collect(Collectors.toList());
         }
-        
-        return nodeList;
+        return list;
     }
     
     public RealtimeBusArrivalInfo getRealtimeBusArrivalInfo(String nodeId){

--- a/src/main/java/org/stupid_talking_potatoes/kis/service/NodeService.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/service/NodeService.java
@@ -9,6 +9,7 @@ import org.stupid_talking_potatoes.kis.entity.Node;
 import org.stupid_talking_potatoes.kis.exception.NotFoundException;
 import org.stupid_talking_potatoes.kis.repository.NodeRepository;
 import org.stupid_talking_potatoes.kis.service.tago.AroundNodeService;
+import org.stupid_talking_potatoes.kis.service.tago.BusArrivalInfoService;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -27,6 +28,7 @@ public class NodeService {
     private final TAGOService tagoService;
     private final RouteService routeService;
     private final AroundNodeService aroundNodeService;
+    private final BusArrivalInfoService busArrivalInfoService;
     
     
     /**
@@ -63,7 +65,7 @@ public class NodeService {
         );
         
         // get response from tago service
-        List<ArrivalRoute> arrivalRoutes = tagoService.requestRealtimeBusArrivalInfo(nodeId);
+        List<ArrivalRoute> arrivalRoutes = busArrivalInfoService.requestRealtimeBusArrivalInfo(nodeId);
         
         // set name of departure
         for (ArrivalRoute arrivalRoute: arrivalRoutes) {

--- a/src/main/java/org/stupid_talking_potatoes/kis/service/NodeService.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/service/NodeService.java
@@ -8,6 +8,7 @@ import org.stupid_talking_potatoes.kis.dto.route.ArrivalRoute;
 import org.stupid_talking_potatoes.kis.entity.Node;
 import org.stupid_talking_potatoes.kis.exception.NotFoundException;
 import org.stupid_talking_potatoes.kis.repository.NodeRepository;
+import org.stupid_talking_potatoes.kis.service.tago.AroundNodeService;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -25,6 +26,7 @@ public class NodeService {
     private final NodeRepository nodeRepository;
     private final TAGOService tagoService;
     private final RouteService routeService;
+    private final AroundNodeService aroundNodeService;
     
     
     /**
@@ -84,7 +86,7 @@ public class NodeService {
      */
     public List<NodeDto> getAroundNodeInfo(Double longitude, Double latitude){
         // get response from tago service
-        List<Node> aroundNodes = tagoService.requestAroundNodeInfo(longitude, latitude);
+        List<Node> aroundNodes = aroundNodeService.requestAroundNodeInfo(longitude, latitude);
         
         // map to NodeDto and return
         return aroundNodes.stream().map(NodeDto::new).toList();

--- a/src/main/java/org/stupid_talking_potatoes/kis/service/NodeService.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/service/NodeService.java
@@ -11,7 +11,6 @@ import org.stupid_talking_potatoes.kis.repository.NodeRepository;
 
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * package :  org.stupid_talking_potatoes.kis.node.service

--- a/src/main/java/org/stupid_talking_potatoes/kis/service/NodeService.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/service/NodeService.java
@@ -49,9 +49,17 @@ public class NodeService {
         }
         return list;
     }
-    
+
+    /**
+     * nodeId를 기준으로 외부 API로부터 해당 정류장의 실시간 버스 도착 정보를 받아와
+     * 해당 버스의 도착지를 추가하여 리턴
+     * @param nodeId 정류장 ID
+     * @return RealtimeBusArrivalInfo (노드 정보 및 버스 도착 정보 리스트)
+     */
     public RealtimeBusArrivalInfo getRealtimeBusArrivalInfo(String nodeId){
-        Node node = nodeRepository.findById(nodeId).orElseThrow(()-> new NotFoundException("Node is not found", nodeId));
+        Node node = nodeRepository.findById(nodeId).orElseThrow(
+                ()-> new NotFoundException("Node is not found", nodeId)
+        );
         
         // get response from tago service
         List<ArrivalRoute> arrivalRoutes = tagoService.requestRealtimeBusArrivalInfo(nodeId);
@@ -65,24 +73,21 @@ public class NodeService {
         // sort by arrTime
         arrivalRoutes.sort(Comparator.comparing(ArrivalRoute::getArrTime));
         
-        // set response
-        RealtimeBusArrivalInfo response = new RealtimeBusArrivalInfo(new NodeDto(node), arrivalRoutes);
-        return response;
+        // set and return response
+        return new RealtimeBusArrivalInfo(new NodeDto(node), arrivalRoutes);
     }
-    
+
+    /**
+     * 좌표 값을 바탕으로 외부 API로부터 주변 정류장 리스트를 받아와 dto로 매핑 후 반환하는 함수
+     * @param longitude 경도
+     * @param latitude 위도
+     * @return 주변 정류장 리스트
+     */
     public List<NodeDto> getAroundNodeInfo(Double longitude, Double latitude){
         // get response from tago service
         List<Node> aroundNodes = tagoService.requestAroundNodeInfo(longitude, latitude);
         
-        // map to NodeDto
-        List<NodeDto> aroundNodeDtos = new ArrayList<NodeDto>();
-        for (Node node: aroundNodes)
-            aroundNodeDtos.add(new NodeDto(node));
-        
-        return aroundNodeDtos;
-    }
-    
-    public  NodeDto getNodeByNaverId(String naverNodeId){
-        return null;
+        // map to NodeDto and return
+        return aroundNodes.stream().map(NodeDto::new).toList();
     }
 }

--- a/src/main/java/org/stupid_talking_potatoes/kis/service/TAGOService.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/service/TAGOService.java
@@ -133,24 +133,6 @@ public class TAGOService {
         return this.filterBusArrivalInfo(arrivalInfoList);
     }
     
-    public List<ArrivalRoute> requestRealtimeSpecificBusArrivalInfo(String nodeId, String routeId) {
-        // set url
-        UriComponents uri = UriComponentsBuilder.newInstance()
-                .scheme("https")
-                .host("apis.data.go.kr")
-                .path("/1613000/ArvlInfoInqireService/getSttnAcctoSpcifyRouteBusArvlPrearngeInfoList")
-                .queryParam("serviceKey", this.serviceKey)
-                // if there is error, return type is always xml.
-                .queryParam("_type", "xml")
-                .queryParam("cityCode", this.cityCode)
-                .queryParam("pageNo", 1)
-                .queryParam("numOfRows", 100)
-                .queryParam("nodeId", nodeId)
-                .queryParam("routeId", routeId)
-                .build();
-        return this.requestAndFilterBusArrivalInfo(uri);
-    }
-    
     public List<ArrivalRoute> requestRealtimeBusArrivalInfo(String nodeId) {
         // set url
         UriComponents uri = UriComponentsBuilder.newInstance()

--- a/src/main/java/org/stupid_talking_potatoes/kis/service/tago/AroundNodeService.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/service/tago/AroundNodeService.java
@@ -1,0 +1,53 @@
+package org.stupid_talking_potatoes.kis.service.tago;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.RequiredArgsConstructor;
+import org.json.JSONObject;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.stupid_talking_potatoes.kis.dto.tago.TAGO_AroundNodeInfo;
+import org.stupid_talking_potatoes.kis.entity.Node;
+
+import java.util.ArrayList;
+
+@Service
+@RequiredArgsConstructor
+public class AroundNodeService extends TagoBaseService<TAGO_AroundNodeInfo, Node> {
+    private String buildUri(Double longitude, Double latitude) {
+        UriComponents uriComponents = UriComponentsBuilder.newInstance()
+                .scheme("https")
+                .host("apis.data.go.kr")
+                .path("/1613000/BusSttnInfoInqireService/getCrdntPrxmtSttnList")
+                .queryParam("serviceKey", this.serviceKey)
+                // if there is error, return type is always xml.
+                .queryParam("_type", "xml")
+                .queryParam("pageNo", 1)
+                .queryParam("numOfRows",100)
+                .queryParam("gpsLong", longitude)
+                .queryParam("gpsLati", latitude)
+                .build();
+        return uriComponents.toString();
+    }
+
+    public ArrayList<Node> requestAroundNodeInfo(Double longitude, Double latitude) {
+        String url = this.buildUri(longitude, latitude);
+        JSONObject responseBody = super.request(url);
+        ArrayList<TAGO_AroundNodeInfo> aroundNodeList = super.convert(responseBody.toString(), new TypeReference<>() {});
+        return this.filter(aroundNodeList);
+    }
+
+    public ArrayList<Node> filter(ArrayList<TAGO_AroundNodeInfo> aroundNodeList) {
+        ArrayList<Node> nodeList = new ArrayList<>();
+        for (TAGO_AroundNodeInfo arrivalInfo: aroundNodeList) {
+            // filter by city code
+            if (arrivalInfo.getCityCode().equals(super.cityCode)) {
+                // encode name to utf-8
+                arrivalInfo.setNodeNm(super.encodeToUTF8(arrivalInfo.getNodeNm()));
+                nodeList.add(Node.of(arrivalInfo));
+            }
+        }
+        return nodeList;
+    }
+
+}

--- a/src/main/java/org/stupid_talking_potatoes/kis/service/tago/AroundNodeService.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/service/tago/AroundNodeService.java
@@ -10,16 +10,18 @@ import org.stupid_talking_potatoes.kis.dto.tago.TAGO_AroundNodeInfo;
 import org.stupid_talking_potatoes.kis.entity.Node;
 
 import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class AroundNodeService extends TagoBaseService<TAGO_AroundNodeInfo, Node> {
+
     private String buildUri(Double longitude, Double latitude) {
         UriComponents uriComponents = UriComponentsBuilder.newInstance()
                 .scheme("https")
                 .host("apis.data.go.kr")
                 .path("/1613000/BusSttnInfoInqireService/getCrdntPrxmtSttnList")
-                .queryParam("serviceKey", this.serviceKey)
+                .queryParam("serviceKey", super.serviceKey)
                 // if there is error, return type is always xml.
                 .queryParam("_type", "xml")
                 .queryParam("pageNo", 1)
@@ -30,16 +32,17 @@ public class AroundNodeService extends TagoBaseService<TAGO_AroundNodeInfo, Node
         return uriComponents.toString();
     }
 
-    public ArrayList<Node> requestAroundNodeInfo(Double longitude, Double latitude) {
+    public List<Node> requestAroundNodeInfo(Double longitude, Double latitude) {
         String url = this.buildUri(longitude, latitude);
         JSONObject responseBody = super.request(url);
-        ArrayList<TAGO_AroundNodeInfo> aroundNodeList = super.convert(responseBody.toString(), new TypeReference<>() {});
-        return this.filter(aroundNodeList);
+        ArrayList<TAGO_AroundNodeInfo> list = super.convert(responseBody.toString(), new TypeReference<>() {});
+        return this.filter(list);
     }
 
-    public ArrayList<Node> filter(ArrayList<TAGO_AroundNodeInfo> aroundNodeList) {
+    protected ArrayList<Node> filter(ArrayList<TAGO_AroundNodeInfo> list) {
         ArrayList<Node> nodeList = new ArrayList<>();
-        for (TAGO_AroundNodeInfo arrivalInfo: aroundNodeList) {
+
+        for (TAGO_AroundNodeInfo arrivalInfo: list) {
             // filter by city code
             if (arrivalInfo.getCityCode().equals(super.cityCode)) {
                 // encode name to utf-8

--- a/src/main/java/org/stupid_talking_potatoes/kis/service/tago/BusArrivalInfoService.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/service/tago/BusArrivalInfoService.java
@@ -1,0 +1,66 @@
+package org.stupid_talking_potatoes.kis.service.tago;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.RequiredArgsConstructor;
+import org.json.JSONObject;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.stupid_talking_potatoes.kis.dto.route.ArrivalRoute;
+import org.stupid_talking_potatoes.kis.dto.tago.TAGO_BusArrivalInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BusArrivalInfoService extends TagoBaseService<TAGO_BusArrivalInfo, ArrivalRoute> {
+
+    private String buildUri(String nodeId) {
+        UriComponents uriComponents = UriComponentsBuilder.newInstance()
+                .scheme("https")
+                .host("apis.data.go.kr")
+                .path("/1613000/ArvlInfoInqireService/getSttnAcctoArvlPrearngeInfoList")
+                .queryParam("serviceKey", super.serviceKey)
+                // if there is error, return type is always xml.
+                .queryParam("_type", "xml")
+                .queryParam("pageNo", 1)
+                .queryParam("numOfRows", 100)
+                .queryParam("cityCode", this.cityCode)
+                .queryParam("nodeId", nodeId)
+                .build();
+        return uriComponents.toString();
+    }
+
+    public List<ArrivalRoute> requestRealtimeBusArrivalInfo(String nodeId) {
+        String url = this.buildUri(nodeId);
+        JSONObject responseBody = super.request(url);
+        ArrayList<TAGO_BusArrivalInfo> list = super.convert(responseBody.toString(), new TypeReference<>() {});
+        return this.filter(list);
+    }
+
+    protected ArrayList<ArrivalRoute> filter(ArrayList<TAGO_BusArrivalInfo> list) {
+        ArrayList<ArrivalRoute> arrivalRoutes = new ArrayList<>();
+
+        for (TAGO_BusArrivalInfo busArrivalInfo: list) {
+            // encode vehicleTp to utf-8
+            String encodedVehicleTp = this.encodeToUTF8(busArrivalInfo.getVehicleTp());
+            // check kneeling bus
+            if (encodedVehicleTp.equals("저상버스")) {
+                // convert time from sec to min
+                int arrTimeSec = busArrivalInfo.getArrTime();
+                int arrTimeMin = this.convertSecToMin(arrTimeSec);
+                // build object and add to list
+                arrivalRoutes.add(
+                        ArrivalRoute.builder()
+                                .routeId(busArrivalInfo.getRouteId())
+                                .routeNo(busArrivalInfo.getRouteNo())
+                                .prevNodeCnt(busArrivalInfo.getArrPrevStationCnt())
+                                .arrTime(arrTimeMin)
+                                .build()
+                );
+            }
+        }
+        return arrivalRoutes;
+    }
+}

--- a/src/main/java/org/stupid_talking_potatoes/kis/service/tago/TagoBaseService.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/service/tago/TagoBaseService.java
@@ -32,15 +32,30 @@ public abstract class TagoBaseService<T, U> {
     protected final String serviceKey = "1XxfhSdKbDyiLDzEHz5mnkYKHAfpwM9SBibMSvTaXf4ybFVKHkQbzGUM1PSPWVTNKK5tG8T9oepg4NcTjgmjGA==";
     protected final Integer cityCode = 37050; // Gumi City Code
 
+    /**
+     * ISO_8859_1 문자열을 UTF8로 인코딩
+     * @param rawString ISO_8859_1로 인코딩된 문자열
+     * @return UTF8로 인코딩된 문자열
+     */
     protected String encodeToUTF8(String rawString) {
         byte[] bytes = rawString.getBytes(StandardCharsets.ISO_8859_1);
         return new String(bytes, StandardCharsets.UTF_8);
     }
 
-    protected int convertSecToMin(int min) {
-        return Math.round((float)min/60);
+    /**
+     * 초 단위를 분 단위로 변경 (나머지는 절삭)
+     * @param sec 초
+     * @return minute
+     */
+    protected int convertSecToMin(int sec) {
+        return Math.round((float)sec/60);
     }
 
+    /**
+     * url에 요청하고 status code를 검사한 후 응답의 xml object를 json object로 변경하여 반환
+     * @param url 외부 api에 요청할 url
+     * @return 요청에 대한 응답의 json body
+     */
     protected JSONObject request(String url) {
         // request
         RestTemplate restTemplate = new RestTemplate();
@@ -58,6 +73,12 @@ public abstract class TagoBaseService<T, U> {
         return XML.toJSONObject(responseXmlBody); // xml to json
     }
 
+    /**
+     * Json body를 T가 담긴 리스트로 변환
+     * @param body Json body
+     * @param typeReference 바꿀 타입 레퍼런스
+     * @return body에서 추출한 T 리스트
+     */
     protected ArrayList<T> convert(String body, TypeReference<ArrayList<T>> typeReference) {
         ObjectMapper objectMapper = new ObjectMapper()
                 // fields of dto are camelCase, but fields of TAGO api are lowercase
@@ -105,5 +126,11 @@ public abstract class TagoBaseService<T, U> {
         }
     }
 
+    /**
+     * TAGO API의 응답을 조건에 맞게 필터링한다.
+     * API 별로 필터링할 조건이 다르기 때문에 상속받는 클래스에서 구현하게 강제한다.
+     * @param list 조건에 맞게 필터링할 리스트
+     * @return 필터링 결과
+     */
     protected abstract ArrayList<U> filter(ArrayList<T> list);
 }

--- a/src/main/java/org/stupid_talking_potatoes/kis/service/tago/TagoBaseService.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/service/tago/TagoBaseService.java
@@ -1,0 +1,104 @@
+package org.stupid_talking_potatoes.kis.service.tago;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import lombok.RequiredArgsConstructor;
+import org.json.JSONObject;
+import org.json.XML;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.stupid_talking_potatoes.kis.exception.InternalServerException;
+import org.stupid_talking_potatoes.kis.exception.ThirdPartyAPIException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+
+/**
+ * TAGO API에 접근하는 Base 서비스
+ * @param <T> TAGO API Response Dto 클래스
+ * @param <U> API의 응답을 필터링한 후 반환되는 List 원소 클래스
+ */
+@Service
+@RequiredArgsConstructor
+public abstract class TagoBaseService<T, U> {
+    protected final String serviceKey = "1XxfhSdKbDyiLDzEHz5mnkYKHAfpwM9SBibMSvTaXf4ybFVKHkQbzGUM1PSPWVTNKK5tG8T9oepg4NcTjgmjGA==";
+    protected final Integer cityCode = 37050; // Gumi City Code
+
+    protected String encodeToUTF8(String rawString) {
+        byte[] bytes = rawString.getBytes(StandardCharsets.ISO_8859_1);
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    protected JSONObject request(String url) {
+        // request
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+
+        // check status code
+        if (response.getStatusCode() != HttpStatusCode.valueOf(200)) {
+            throw ThirdPartyAPIException.builder()
+                    .message("TAGO API Error")
+                    .content(response.getStatusCode().toString())
+                    .build();
+        }
+
+        String responseXmlBody = response.getBody(); // get xml body
+        return XML.toJSONObject(responseXmlBody); // xml to json
+    }
+
+    protected ArrayList<T> convert(String body, TypeReference<ArrayList<T>> typeReference) {
+        ObjectMapper objectMapper = new ObjectMapper()
+                // fields of dto are camelCase, but fields of TAGO api are lowercase
+                .setPropertyNamingStrategy(PropertyNamingStrategy.LOWER_CASE);
+        try {
+            // json string to JsonNode
+            JsonNode jsonNode = objectMapper.readTree(body);
+
+            // get header -> check resultCode
+            JsonNode responseHeader = jsonNode.get("response").get("header");
+            if (!responseHeader.get("resultCode").asText().equals("00")) { // when there is error
+                throw ThirdPartyAPIException.builder()
+                        .message("TAGO API Error")
+                        .content(responseHeader.get("resultMsg").asText())
+                        .build();
+            }
+
+            // get body -> check items count
+            JsonNode responseBody = jsonNode.get("response").get("body");
+            if (responseBody.get("totalCount").asInt() == 0) { // when items is empty
+                return new ArrayList<>();
+            }
+
+            // convert items to object list & return
+            ArrayNode arrayNode = (ArrayNode) responseBody.get("items").get("item");
+
+            ArrayList<T> aroundNodeList = objectMapper.convertValue(arrayNode, typeReference);
+            return aroundNodeList;
+
+        } catch (JsonMappingException e) {
+            throw InternalServerException.builder()
+                    .message("Json Mapping Exception")
+                    .content(e.getMessage())
+                    .build();
+        } catch (JsonProcessingException e) {
+            throw InternalServerException.builder()
+                    .message("Json Processing Exception")
+                    .content(e.getMessage())
+                    .build();
+        } catch (NullPointerException e) {
+            throw InternalServerException.builder()
+                    .message("Null Pointer Exception")
+                    .content(e.getMessage())
+                    .build();
+        }
+    }
+
+    protected abstract ArrayList<U> filter(ArrayList<T> list);
+}

--- a/src/main/java/org/stupid_talking_potatoes/kis/service/tago/TagoBaseService.java
+++ b/src/main/java/org/stupid_talking_potatoes/kis/service/tago/TagoBaseService.java
@@ -28,12 +28,17 @@ import java.util.ArrayList;
 @Service
 @RequiredArgsConstructor
 public abstract class TagoBaseService<T, U> {
+
     protected final String serviceKey = "1XxfhSdKbDyiLDzEHz5mnkYKHAfpwM9SBibMSvTaXf4ybFVKHkQbzGUM1PSPWVTNKK5tG8T9oepg4NcTjgmjGA==";
     protected final Integer cityCode = 37050; // Gumi City Code
 
     protected String encodeToUTF8(String rawString) {
         byte[] bytes = rawString.getBytes(StandardCharsets.ISO_8859_1);
         return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    protected int convertSecToMin(int min) {
+        return Math.round((float)min/60);
     }
 
     protected JSONObject request(String url) {

--- a/src/test/java/org/stupid_talking_potatoes/kis/service/NodeServiceTest.java
+++ b/src/test/java/org/stupid_talking_potatoes/kis/service/NodeServiceTest.java
@@ -13,6 +13,7 @@ import org.stupid_talking_potatoes.kis.dto.node.RealtimeBusArrivalInfo;
 import org.stupid_talking_potatoes.kis.dto.route.ArrivalRoute;
 import org.stupid_talking_potatoes.kis.entity.Node;
 import org.stupid_talking_potatoes.kis.repository.NodeRepository;
+import org.stupid_talking_potatoes.kis.service.tago.AroundNodeService;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,19 +27,18 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class NodeServiceTest {
     private static NodeService nodeService;
-    
     private static NodeRepository nodeRepository;
-    
     private static RouteService routeService;
-    
     private static TAGOService tagoService;
+    private static AroundNodeService aroundNodeService;
     
     @BeforeAll
     public static void set() {
         nodeRepository = Mockito.mock(NodeRepository.class);
         tagoService = Mockito.mock(TAGOService.class);
         routeService = Mockito.mock(RouteService.class);
-        nodeService = new NodeService(nodeRepository, tagoService, routeService);
+        aroundNodeService = Mockito.mock(AroundNodeService.class);
+        nodeService = new NodeService(nodeRepository, tagoService, routeService, aroundNodeService);
     }
     
     @Nested

--- a/src/test/java/org/stupid_talking_potatoes/kis/service/NodeServiceTest.java
+++ b/src/test/java/org/stupid_talking_potatoes/kis/service/NodeServiceTest.java
@@ -14,6 +14,7 @@ import org.stupid_talking_potatoes.kis.dto.route.ArrivalRoute;
 import org.stupid_talking_potatoes.kis.entity.Node;
 import org.stupid_talking_potatoes.kis.repository.NodeRepository;
 import org.stupid_talking_potatoes.kis.service.tago.AroundNodeService;
+import org.stupid_talking_potatoes.kis.service.tago.BusArrivalInfoService;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,6 +32,7 @@ public class NodeServiceTest {
     private static RouteService routeService;
     private static TAGOService tagoService;
     private static AroundNodeService aroundNodeService;
+    private static BusArrivalInfoService busArrivalInfoService;
     
     @BeforeAll
     public static void set() {
@@ -38,7 +40,8 @@ public class NodeServiceTest {
         tagoService = Mockito.mock(TAGOService.class);
         routeService = Mockito.mock(RouteService.class);
         aroundNodeService = Mockito.mock(AroundNodeService.class);
-        nodeService = new NodeService(nodeRepository, tagoService, routeService, aroundNodeService);
+        busArrivalInfoService = Mockito.mock(BusArrivalInfoService.class);
+        nodeService = new NodeService(nodeRepository, tagoService, routeService, aroundNodeService, busArrivalInfoService);
     }
     
     @Nested

--- a/src/test/java/org/stupid_talking_potatoes/kis/service/NodeServiceTest.java
+++ b/src/test/java/org/stupid_talking_potatoes/kis/service/NodeServiceTest.java
@@ -58,7 +58,7 @@ public class NodeServiceTest {
             when(nodeRepository.findByNodeNameContaining(name)).thenReturn(nodes);
             
             // when
-            ArrayList<NodeDto> response = nodeService.getNodeList(null, name);
+            List<NodeDto> response = nodeService.getNodeList(null, name);
             
             // then
             assertEquals(2, response.size());
@@ -74,7 +74,7 @@ public class NodeServiceTest {
             when (nodeRepository.findByNodeNo(no)).thenReturn(Optional.of(node));
             
             // when
-            ArrayList<NodeDto> response = nodeService.getNodeList(no, null);
+            List<NodeDto> response = nodeService.getNodeList(no, null);
             
             // then
             assertEquals(1, response.size());


### PR DESCRIPTION
# 변경 유형
 - [X] 버그 수정
 - [ ] 기능 추가
 - [ ] 코드 스타일 업데이트 (서식, 로컬 변수)
 - [X] 리팩토링 (기능 변경 없음, API 변경 없음)
 - [ ] 빌드 관련 변경
 - [ ] CI 관련 변경
 - [ ] 문서 내용 변경
 - [ ] 애플리케이션/인프라 변경
 - [ ] 기타... 설명:
# 변경 내용
- Exception Handler, Base Exception 추가
- 각종 상황에 맞는 예외를 Base Exception에서 상속하여 사용
- TAGO Service에 코드가 너무 길어지는 것 같아 refactoring (우선 실시간 버스 도착 정보 조회, 주변 정류장 목록 조회에만 적용)
  - API 별 클래스 분리
  - 공통으로 사용하거나 하위 클래스에서 구현해야 하는 부분은 TAGO Base Service에 구현
  - 기존 TAGOService에 요청하는 함수의 prototype은 그대로 두고, 해당 함수에서 url 빌드 -> request -> convert -> filter 하는 과정으로 획일화함
  - convert 내용이 같기 때문에 제네릭 타입과 TypeReference를 넘겨주어 공통으로 사용할 수 있게 함 
    - 이 부분은 에러 처리가 조금 더 필요하고, 실시간 버스 위치 정보 조회에도 잘 적용되는지 확인해야 함
    - 그리고 _API 응답의 아이템이 하나인 경우 객체로 오는 경우가 있다고 들어서 테스트 필요_ 
# 참조 자료
- 

Closes #29 